### PR TITLE
chore(nx): update AI agents configuration

### DIFF
--- a/.agents/skills/monitor-ci/SKILL.md
+++ b/.agents/skills/monitor-ci/SKILL.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.agents/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.agents/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -13,10 +13,15 @@
  * Usage:
  *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
  *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
- *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
- *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-status <status>] [--timeout <minutes>] [--new-cipe-timeout <minutes>] \
+ *     [--elapsed-seconds <n>] [--env-rerun-count <n>] [--no-progress-count <n>] \
  *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
  *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ *
+ * Note: --timeout and --new-cipe-timeout are accepted in MINUTES (matching the
+ * skill's documented flags) and converted to seconds internally. --elapsed-seconds
+ * is the wall-clock time since monitoring began, carried across attempts by the
+ * orchestrator, and is the authoritative signal for the --timeout budget.
  */
 
 // --- Arg parsing ---
@@ -39,8 +44,14 @@ const waitMode = getFlag('--wait-mode');
 const prevCipeUrl = getArg('--prev-cipe-url');
 const expectedSha = getArg('--expected-sha');
 const prevStatus = getArg('--prev-status');
-const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
-const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+// Flags are documented in minutes; convert to seconds for internal comparison.
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10) * 60;
+const newCipeTimeoutSeconds =
+  parseInt(getArg('--new-cipe-timeout') || '0', 10) * 60;
+// Wall-clock seconds since monitoring began (carried across attempts); null when
+// the orchestrator doesn't supply it (see isTimedOut for that fallback).
+const elapsedArg = getArg('--elapsed-seconds');
+const elapsedSeconds = elapsedArg !== null ? parseInt(elapsedArg, 10) : null;
 const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
 const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
 const prevCipeStatus = getArg('--prev-cipe-status');
@@ -125,6 +136,11 @@ function hasStateChanged() {
 
 function isTimedOut() {
   if (timeoutSeconds <= 0) return false;
+  // Prefer real wall-clock elapsed (carried across attempts) so --timeout caps
+  // total monitor duration, not a single invocation.
+  if (elapsedSeconds !== null && !Number.isNaN(elapsedSeconds))
+    return elapsedSeconds >= timeoutSeconds;
+  // Fallback: estimate elapsed from poll cadence within this invocation.
   const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
   return pollCount * avgDelay >= timeoutSeconds;
 }
@@ -179,6 +195,10 @@ function classify() {
   // --- Wait mode ---
   if (waitMode) {
     if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    // The total --timeout budget also caps time spent waiting for a new CI
+    // Attempt, so it must win over --new-cipe-timeout here; otherwise a long
+    // wait (or a sequence of apply→wait cycles) could run past --timeout.
+    if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
     if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
     return { action: 'wait', code: 'waiting_for_cipe' };
   }

--- a/.agents/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.agents/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -129,7 +129,9 @@ function cycleCheck() {
   // Reset env_rerun_count on non-environment status
   if (status !== 'environment_issue') envRerunCount = 0;
 
-  // Approaching limit gate
+  // Cycle limit gates. limitReached is a terminal stop; approachingLimit is an
+  // advisory warning emitted in the two cycles before the cap.
+  const limitReached = cycleCount >= maxCycles;
   const approachingLimit = cycleCount >= maxCycles - 2;
 
   output({
@@ -137,9 +139,12 @@ function cycleCheck() {
     agentTriggered: false,
     envRerunCount,
     approachingLimit,
-    message: approachingLimit
-      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
-      : null,
+    limitReached,
+    message: limitReached
+      ? `Cycle limit reached (${cycleCount}/${maxCycles}). Stopping.`
+      : approachingLimit
+        ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+        : null,
   });
 }
 

--- a/.gemini/commands/monitor-ci.toml
+++ b/.gemini/commands/monitor-ci.toml
@@ -140,7 +140,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -177,8 +177,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \\
   [--expected-sha <expected_commit_sha>] \\
   [--prev-status <prev_status>] \\
-  [--timeout <timeout_seconds>] \\
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \\
+  [--timeout <timeout_minutes>] \\
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \\
+  [--elapsed-seconds <seconds_since_start_time>] \\
   [--env-rerun-count <env_rerun_count>] \\
   [--no-progress-count <no_progress_count>] \\
   [--prev-cipe-status <prev_cipe_status>] \\
@@ -186,6 +187,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \\
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -259,9 +262,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \\
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.github/prompts/monitor-ci.prompt.md
+++ b/.github/prompts/monitor-ci.prompt.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.github/skills/monitor-ci/SKILL.md
+++ b/.github/skills/monitor-ci/SKILL.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.github/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.github/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -13,10 +13,15 @@
  * Usage:
  *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
  *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
- *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
- *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-status <status>] [--timeout <minutes>] [--new-cipe-timeout <minutes>] \
+ *     [--elapsed-seconds <n>] [--env-rerun-count <n>] [--no-progress-count <n>] \
  *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
  *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ *
+ * Note: --timeout and --new-cipe-timeout are accepted in MINUTES (matching the
+ * skill's documented flags) and converted to seconds internally. --elapsed-seconds
+ * is the wall-clock time since monitoring began, carried across attempts by the
+ * orchestrator, and is the authoritative signal for the --timeout budget.
  */
 
 // --- Arg parsing ---
@@ -39,8 +44,14 @@ const waitMode = getFlag('--wait-mode');
 const prevCipeUrl = getArg('--prev-cipe-url');
 const expectedSha = getArg('--expected-sha');
 const prevStatus = getArg('--prev-status');
-const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
-const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+// Flags are documented in minutes; convert to seconds for internal comparison.
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10) * 60;
+const newCipeTimeoutSeconds =
+  parseInt(getArg('--new-cipe-timeout') || '0', 10) * 60;
+// Wall-clock seconds since monitoring began (carried across attempts); null when
+// the orchestrator doesn't supply it (see isTimedOut for that fallback).
+const elapsedArg = getArg('--elapsed-seconds');
+const elapsedSeconds = elapsedArg !== null ? parseInt(elapsedArg, 10) : null;
 const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
 const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
 const prevCipeStatus = getArg('--prev-cipe-status');
@@ -125,6 +136,11 @@ function hasStateChanged() {
 
 function isTimedOut() {
   if (timeoutSeconds <= 0) return false;
+  // Prefer real wall-clock elapsed (carried across attempts) so --timeout caps
+  // total monitor duration, not a single invocation.
+  if (elapsedSeconds !== null && !Number.isNaN(elapsedSeconds))
+    return elapsedSeconds >= timeoutSeconds;
+  // Fallback: estimate elapsed from poll cadence within this invocation.
   const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
   return pollCount * avgDelay >= timeoutSeconds;
 }
@@ -179,6 +195,10 @@ function classify() {
   // --- Wait mode ---
   if (waitMode) {
     if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    // The total --timeout budget also caps time spent waiting for a new CI
+    // Attempt, so it must win over --new-cipe-timeout here; otherwise a long
+    // wait (or a sequence of apply→wait cycles) could run past --timeout.
+    if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
     if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
     return { action: 'wait', code: 'waiting_for_cipe' };
   }

--- a/.github/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.github/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -129,7 +129,9 @@ function cycleCheck() {
   // Reset env_rerun_count on non-environment status
   if (status !== 'environment_issue') envRerunCount = 0;
 
-  // Approaching limit gate
+  // Cycle limit gates. limitReached is a terminal stop; approachingLimit is an
+  // advisory warning emitted in the two cycles before the cap.
+  const limitReached = cycleCount >= maxCycles;
   const approachingLimit = cycleCount >= maxCycles - 2;
 
   output({
@@ -137,9 +139,12 @@ function cycleCheck() {
     agentTriggered: false,
     envRerunCount,
     approachingLimit,
-    message: approachingLimit
-      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
-      : null,
+    limitReached,
+    message: limitReached
+      ? `Cycle limit reached (${cycleCount}/${maxCycles}). Stopping.`
+      : approachingLimit
+        ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+        : null,
   });
 }
 

--- a/.opencode/commands/monitor-ci.md
+++ b/.opencode/commands/monitor-ci.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.opencode/skills/monitor-ci/SKILL.md
+++ b/.opencode/skills/monitor-ci/SKILL.md
@@ -143,7 +143,7 @@ The decision script returns one of the following statuses. This table defines th
 
 ```
 cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
-start_time = now()
+start_time = now()         # Passed to the decision script as --elapsed-seconds on every poll to enforce --timeout across attempts
 no_progress_count = 0
 local_verify_count = 0
 env_rerun_count = 0
@@ -180,8 +180,9 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-cipe-url <last_cipe_url>] \
   [--expected-sha <expected_commit_sha>] \
   [--prev-status <prev_status>] \
-  [--timeout <timeout_seconds>] \
-  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--timeout <timeout_minutes>] \
+  [--new-cipe-timeout <new_cipe_timeout_minutes>] \
+  [--elapsed-seconds <seconds_since_start_time>] \
   [--env-rerun-count <env_rerun_count>] \
   [--no-progress-count <no_progress_count>] \
   [--prev-cipe-status <prev_cipe_status>] \
@@ -189,6 +190,8 @@ node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count
   [--prev-verification-status <prev_verification_status>] \
   [--prev-failure-classification <prev_failure_classification>]
 ```
+
+Pass `--timeout` and `--new-cipe-timeout` in **minutes** (the values from Configuration Defaults) — the script converts to seconds internally. Pass `--elapsed-seconds` as the whole seconds elapsed since `start_time` (`now() - start_time`); this is what enforces `--timeout` as a **total** monitor budget across every poll and attempt, so it must be supplied on every call once monitoring has started.
 
 The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
 
@@ -262,9 +265,10 @@ node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
   --env-rerun-count <env_rerun_count>
 ```
 
-The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, limitReached, message }`. Update tracking state from the output.
 
-- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If `limitReached` → the `--max-cycles` budget is exhausted. Print `message` and **stop monitoring** (do not handle the code or start another cycle). This is a hard stop, not advisory.
+- Else if `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
 - If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
 
 #### Progress Tracking

--- a/.opencode/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.opencode/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -13,10 +13,15 @@
  * Usage:
  *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
  *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
- *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
- *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-status <status>] [--timeout <minutes>] [--new-cipe-timeout <minutes>] \
+ *     [--elapsed-seconds <n>] [--env-rerun-count <n>] [--no-progress-count <n>] \
  *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
  *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ *
+ * Note: --timeout and --new-cipe-timeout are accepted in MINUTES (matching the
+ * skill's documented flags) and converted to seconds internally. --elapsed-seconds
+ * is the wall-clock time since monitoring began, carried across attempts by the
+ * orchestrator, and is the authoritative signal for the --timeout budget.
  */
 
 // --- Arg parsing ---
@@ -39,8 +44,14 @@ const waitMode = getFlag('--wait-mode');
 const prevCipeUrl = getArg('--prev-cipe-url');
 const expectedSha = getArg('--expected-sha');
 const prevStatus = getArg('--prev-status');
-const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
-const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+// Flags are documented in minutes; convert to seconds for internal comparison.
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10) * 60;
+const newCipeTimeoutSeconds =
+  parseInt(getArg('--new-cipe-timeout') || '0', 10) * 60;
+// Wall-clock seconds since monitoring began (carried across attempts); null when
+// the orchestrator doesn't supply it (see isTimedOut for that fallback).
+const elapsedArg = getArg('--elapsed-seconds');
+const elapsedSeconds = elapsedArg !== null ? parseInt(elapsedArg, 10) : null;
 const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
 const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
 const prevCipeStatus = getArg('--prev-cipe-status');
@@ -125,6 +136,11 @@ function hasStateChanged() {
 
 function isTimedOut() {
   if (timeoutSeconds <= 0) return false;
+  // Prefer real wall-clock elapsed (carried across attempts) so --timeout caps
+  // total monitor duration, not a single invocation.
+  if (elapsedSeconds !== null && !Number.isNaN(elapsedSeconds))
+    return elapsedSeconds >= timeoutSeconds;
+  // Fallback: estimate elapsed from poll cadence within this invocation.
   const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
   return pollCount * avgDelay >= timeoutSeconds;
 }
@@ -179,6 +195,10 @@ function classify() {
   // --- Wait mode ---
   if (waitMode) {
     if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    // The total --timeout budget also caps time spent waiting for a new CI
+    // Attempt, so it must win over --new-cipe-timeout here; otherwise a long
+    // wait (or a sequence of apply→wait cycles) could run past --timeout.
+    if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
     if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
     return { action: 'wait', code: 'waiting_for_cipe' };
   }

--- a/.opencode/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.opencode/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -129,7 +129,9 @@ function cycleCheck() {
   // Reset env_rerun_count on non-environment status
   if (status !== 'environment_issue') envRerunCount = 0;
 
-  // Approaching limit gate
+  // Cycle limit gates. limitReached is a terminal stop; approachingLimit is an
+  // advisory warning emitted in the two cycles before the cap.
+  const limitReached = cycleCount >= maxCycles;
   const approachingLimit = cycleCount >= maxCycles - 2;
 
   output({
@@ -137,9 +139,12 @@ function cycleCheck() {
     agentTriggered: false,
     envRerunCount,
     approachingLimit,
-    message: approachingLimit
-      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
-      : null,
+    limitReached,
+    message: limitReached
+      ? `Cycle limit reached (${cycleCount}/${maxCycles}). Stopping.`
+      : approachingLimit
+        ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+        : null,
   });
 }
 


### PR DESCRIPTION
## Summary

Applies the Nx Console "newer AI agent configuration available" update, syncing the `monitor-ci` skill across the `.agents/`, `.github/`, `.gemini/` and `.opencode/` mirrors:

- `--timeout` and `--new-cipe-timeout` are now taken in **minutes** and converted to seconds internally
- new `--elapsed-seconds` flag makes `--timeout` a **total** monitor budget enforced across every poll and attempt (including wait mode)
- `cycle-check` now returns `limitReached` as a hard stop when the `--max-cycles` budget is exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)